### PR TITLE
Run CodeQL with the security-and-quality query suite

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,10 @@ jobs:
         uses: github/codeql-action/init@v4
         with:
           languages: ruby
+          # Default suite is high-precision security only. security-and-quality adds
+          # the extended security queries plus maintainability/reliability queries
+          # (dead code, unused assignments, correctness smells).
+          queries: security-and-quality
 
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@v4


### PR DESCRIPTION
## What

Add `queries: security-and-quality` to the CodeQL `init` step in `.github/workflows/ci.yml`.

## Why

The default CodeQL pack runs only the high-precision **security** queries. `security-and-quality` is the superset: it includes the extended security queries **plus** CodeQL's maintainability/reliability queries (dead code, unused assignments, some correctness smells). This broadens what CodeQL surfaces on each push/PR without adding a new tool.

It does **not** replace a style linter — RuboCop/Standard (style, complexity, idioms) and Overcommit hooks are intentionally out of scope here and will be added separately.

## Risk

Low. Same job, same action (`github/codeql-action@v4`), one added input. CodeQL findings are reported as alerts in the Security tab; they don't fail the job, so nothing that merged before will be blocked now — there may just be a few new advisory-level findings to triage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
